### PR TITLE
Additional region pattern for s3 urls

### DIFF
--- a/lib/resty/aws.lua
+++ b/lib/resty/aws.lua
@@ -90,7 +90,7 @@ local function get_service_and_region(host)
   local patterns = {
     {'s3.amazonaws.com', 's3', 'us-east-1'},
     {'s3-external-1.amazonaws.com', 's3', 'us-east-1'},
-    {'s3%.([a-z0-9-]+)%.amazonaws%.com', 's3', nil}
+    {'s3%.([a-z0-9-]+)%.amazonaws%.com', 's3', nil},
     {'s3%-([a-z0-9-]+)%.amazonaws%.com', 's3', nil}
   }
 

--- a/lib/resty/aws.lua
+++ b/lib/resty/aws.lua
@@ -90,6 +90,7 @@ local function get_service_and_region(host)
   local patterns = {
     {'s3.amazonaws.com', 's3', 'us-east-1'},
     {'s3-external-1.amazonaws.com', 's3', 'us-east-1'},
+    {'s3%.([a-z0-9-]+)%.amazonaws%.com', 's3', nil}
     {'s3%-([a-z0-9-]+)%.amazonaws%.com', 's3', nil}
   }
 


### PR DESCRIPTION
Support urls like (bucket).s3.(region).amazonaws.com